### PR TITLE
Update application link details without removing applink.

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -2613,36 +2613,6 @@ endif::internal-generation[]
 | 
 | date-time 
 
-| server 
-|  
-| DirectoryLdapServer  
-| 
-|  
-
-| permissions 
-|  
-| DirectoryLdapPermissions  
-| 
-|  
-
-| advanced 
-|  
-| DirectoryInternalAdvanced  
-| 
-|  
-
-| credentialPolicy 
-|  
-| DirectoryInternalCredentialPolicy  
-| 
-|  
-
-| schema 
-|  
-| DirectoryLdapSchema  
-| 
-|  
-
 |===
 
 

--- a/src/main/java/de/aservo/confapi/jira/service/ApplicationLinkServiceImpl.java
+++ b/src/main/java/de/aservo/confapi/jira/service/ApplicationLinkServiceImpl.java
@@ -122,16 +122,22 @@ public class ApplicationLinkServiceImpl implements ApplicationLinksService {
         ApplicationId id = new ApplicationId(uuid.toString());
 
         try {
-            //entity must be removed first (there is no update service method)
-            ApplicationLink applicationLink = mutatingApplicationLinkService.getApplicationLink(id);
-            mutatingApplicationLinkService.deleteApplicationLink(applicationLink);
-
-            //finally a new entity is added with the known existing server id
-            ApplicationLinkDetails linkDetails = ApplicationLinkBeanUtil.toApplicationLinkDetails(applicationLinkBean);
+            MutableApplicationLink applicationLink = mutatingApplicationLinkService.getApplicationLink(id);
             ApplicationType applicationType = buildApplicationType(applicationLinkBean.getType());
+            ApplicationLinkDetails linkDetails = ApplicationLinkBeanUtil.toApplicationLinkDetails(applicationLinkBean);
+
+            if (applicationLink.getType().equals(applicationType)
+                    && applicationLinkBean.getPassword() == null
+                    && applicationLinkBean.getUsername() == null) {
+                applicationLink.update(linkDetails);
+                return getApplicationLinkBeanWithStatus(applicationLink);
+            }
+
+            //entity must be removed first (there is no update service method)
+            mutatingApplicationLinkService.deleteApplicationLink(applicationLink);
+            //finally a new entity is added with the known existing server id
             MutableApplicationLink mutableApplicationLink = mutatingApplicationLinkService.addApplicationLink(id, applicationType, linkDetails);
             return getApplicationLinkBeanWithStatus(mutableApplicationLink);
-
         } catch (TypeNotInstalledException e) {
             throw new BadRequestException(e.getMessage());
         }
@@ -197,7 +203,7 @@ public class ApplicationLinkServiceImpl implements ApplicationLinksService {
         }
     }
 
-    private ApplicationType buildApplicationType(ApplicationLinkType linkType) {
+    protected ApplicationType buildApplicationType(ApplicationLinkType linkType) {
         switch (linkType) {
             case BAMBOO:
                 return typeAccessor.getApplicationType(BambooApplicationType.class);


### PR DESCRIPTION
Similar to confluence, add functionality to update an application link's details by skipping remove/add applink steps.